### PR TITLE
fix low-temp

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1102,9 +1102,9 @@ var maxDelta_bg_threshold;
             } else if (durationReq >= 30) {
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(60,Math.max(0,durationReq));
-            } else {
+            } else { // 0 < durationReq < 30
                 // if SMB durationReq is less than 30m, set a nonzero low temp
-                smbLowTempReq = round( basal * durationReq/30 ,2);
+                smbLowTempReq = round_basal( basal * (30 - durationReq)/30 , profile);
                 durationReq = 30;
             }
             rT.reason += " insulinReq " + insulinReq;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -356,7 +356,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
-    if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate !== iob_data.lastTemp.rate && lastTempAge > 10 && currenttemp.duration ) {
+    if ( microBolusAllowed && currenttemp && currenttemp.rate && iob_data.lastTemp && iob_data.lastTemp.rate && Math.abs(currenttemp.rate - iob_data.lastTemp.rate) > 0.001 && lastTempAge > 10 && currenttemp.duration ) {
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; canceling temp";
         return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
     }


### PR DESCRIPTION
When setting a low temp (to simulate a short zero-temp), oref0 had two issues:
	1.	No rounding – it didn’t use `round_basal()`, producing rates like `0.02` U/hr 
	2.	Inverted logic – for short zero-temps (`durationReq < 30 min`), the formula used to compute the equivalent 30-minute low-temp rate was reversed.

But more importantly, the low temp logic here was completely backwards (in one of the cases).

### Context

This logic runs when:
* oref0 suggests an SMB, and
* a zero-temp is required to withhold some insulin.

The intended behavior:
* If `durationReq ≤ 0` → no zero-temp (later code may set a high-temp).
* If `durationReq ≥ 30` → set a full zero-temp (0 U/h) for that duration.
* If `0 < durationReq < 30` → simulate this zero-temp by setting a 30-minute "low-temp", such that the total insulin delivered matches “zero for `durationReq` minutes, then basal for the rest.”

The rate calculation for the the last scenario was inverted. 
Instead of calculating the temp rate like this:
```
# requiredZeroDuration minutes of zero rate, (30 - requiredZeroDuration) minutes of profile basal rate
tempRate = (profileBasalRate * (30 - requiredZeroDuration) / 30  
```
it was implemented as this:
```
# requiredZeroDuration minutes of profile basal rate, (30 - requiredZeroDuration) minutes of zero rate
tempRate = (profileBasalRate * requiredZeroDuration / 30
```

An example from my recent logs:
```
Adjusting basal from 0.65 to 1.05; 
...
...
"reason": "COB: 0, Dev: 2.2, BGI: -0.4, ISF: 1.7, CR: 10.8, minPredBG: 5.7, minGuardBG: 4.9, IOBpredBG: 5.7, UAMpredBG: 4.9; Eventual BG 6 >= 5.2,  insulinReq 0.26; setting 30m low temp of 0.88U/h. Microbolusing 0.2U. ",
```

Insulin required is merely `0.26` units -> `0.2` units SMB with a zero-temp for 25 minutes  and it should have been simulated with a 30-min TBR with rate = `1.05 / 30 * (30-25) = 0.18`. Instead, it was `1.05 / 30 * 25 = 0.88` - not a low temp at all.