### PR TITLE
IOB calculation - fix TBR splitting

### DIFF
--- a/bin/oref0-calculate-full-iob.js
+++ b/bin/oref0-calculate-full-iob.js
@@ -44,14 +44,19 @@ var oref0_calculate_iob = function oref0_calculate_iob(argv_params) {
 
   var pumphistory_input = inputs[0];
   var profile_input = inputs[1];
-  var clock_input = inputs[2];
-  var autosens_input = inputs[3];
-  var pumphistory_24_input = inputs[4];
+  var time_from = typeof inputs[2] === 'string' ? new Date(Date.parse(inputs[2])) : undefined;
+  var time_until = typeof inputs[3] === 'string' ? new Date(Date.parse(inputs[3])) : undefined;
+  var autosens_input = inputs[4];
+  var pumphistory_24_input = inputs[5];
+
+  if (!time_from || !time_until) {
+    console.error("time_from and time_until are required")
+    return
+  }
 
   var cwd = process.cwd();
   var pumphistory_data = JSON.parse(fs.readFileSync(pumphistory_input));
   var profile_data = JSON.parse(fs.readFileSync(profile_input));
-  var clock_data = JSON.parse(fs.readFileSync(clock_input));
 
   var autosens_data = null;
   if (autosens_input && autosens_input !== '') {
@@ -69,18 +74,30 @@ var oref0_calculate_iob = function oref0_calculate_iob(argv_params) {
 
   // pumphistory_data.sort(function (a, b) { return a.date > b.date });
 
-  inputs = {
-    history: pumphistory_data
-  , history24: pumphistory_24_data
-  , profile: profile_data
-  , clock: clock_data
-  };
-  if ( autosens_data ) {
-    inputs.autosens = autosens_data;
-  }
+  var now = time_until
+  var all_iob = []
+  while (now >= time_from) {
+    inputs = {
+      history: pumphistory_data
+      , history24: pumphistory_24_data
+      , profile: profile_data
+      , clock: now.toISOString()
+    };
+    if (autosens_data) {
+      inputs.autosens = autosens_data;
+    }
 
-  var iob = generate(inputs);
-  return(JSON.stringify(iob));
+    var iob = generate(inputs);
+    if (iob.length > 0) {
+      if (now === time_until) {
+        all_iob = iob
+      } else {
+        all_iob.unshift(iob[0])
+      }
+    }
+    now = new Date(now.getTime() - 5 * 60 * 1000)
+  }
+  return(JSON.stringify(all_iob));
 }
 
 if (!module.parent) {

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -57,9 +57,9 @@ function splitTimespan(event, splitterMoments) {
     while(splitFound) {
 
         var resultArray = [];
-        splitFound = false;
 
         _.forEach(results,function split(o) {
+            splitFound = false;
             _.forEach(splitterMoments,function split(p) {
                 var splitResult = splitTimespanWithOneSplitter(o,p);
                 if (splitResult.length > 1) {
@@ -102,11 +102,11 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
         }
     }
 
-    if (currentlySuspended && ((currentEvent.date+currentEvent.duration*60*1000) > lastSuspendTime)) {
-        if (currentEvent.date > lastSuspendTime) {
+    if (currentlySuspended && lastSuspendDate && ((currentEvent.date+currentEvent.duration*60*1000) > lastSuspendDate)) {
+        if (currentEvent.date > lastSuspendDate) {
             currentEvent.duration = 0;
         } else {
-            currentEvent.duration = (firstResumeDate - currentEvent.date)/60/1000;
+            currentEvent.duration = (lastSuspendDate - currentEvent.date)/60/1000;
         }
     }
 
@@ -366,18 +366,18 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             tempHistory.push(temp);
         }
         // Add a temp basal cancel event to ignore future temps and reduce predBG oscillation
-        var temp = {};
-        temp.rate = 0;
-        // start the zero temp 1m in the future to avoid clock skew
-        temp.started_at = new Date(now.getTime() + (1 * 60 * 1000));
-        temp.date = temp.started_at.getTime();
-        if (zeroTempDuration) {
-            temp.duration = zeroTempDuration;
-        } else {
-            temp.duration = 0;
-        }
-        tempHistory.push(temp);
     }
+    var temp = {};
+    temp.rate = 0;
+    // start the zero temp 1m in the future to avoid clock skew
+    temp.started_at = new Date(now.getTime() + (60 * 1000));
+    temp.date = temp.started_at.getTime();
+    if (zeroTempDuration) {
+      temp.duration = zeroTempDuration;
+    } else {
+      temp.duration = 0;
+    }
+    tempHistory.push(temp);
 
     // Check for overlapping events and adjust event lengths in case of overlap
 
@@ -422,7 +422,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
     }
 
     if (suspend_zeros_iob) {
-        // iterate through the events and adjust their 
+        // iterate through the events and adjust their
         // times as required to account for pump suspends
         var splitHistory = [];
 
@@ -436,14 +436,16 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         // Any existing temp basals during times the pump was suspended are now deleted
         // Add 0 temp basals to negate the profile basal rates during times pump is suspended
         _.forEach(pumpSuspends, function createTempBasal(o) {
-            var zTempBasal = [{
-                _type: 'SuspendBasal',
-                rate: 0,
-                duration: o.duration,
-                date: o.date,
-                started_at: o.started_at
-            }];
-            zTempSuspendBasals = zTempSuspendBasals.concat(zTempBasal);
+            if (typeof o.duration !== 'undefined') {
+                var zTempBasal = [{
+                    _type: 'SuspendBasal',
+                    rate: 0,
+                    duration: o.duration,
+                    date: o.date,
+                    started_at: o.started_at
+                }];
+                zTempSuspendBasals = zTempSuspendBasals.concat(zTempBasal);
+            }
         });
 
         // Add temp suspend basal for maximum DIA (8) up to the resume time


### PR DESCRIPTION
Fixing a couple of rather bad bugs in IOB calculations.

## Not "zeroing" TBRs during pump suspends

This was happening due to a "typo":
```js
if (currentlySuspended && ((currentEvent.date+currentEvent.duration*60*1000) > lastSuspendTime)) {
```

`lastSuspendTime` is a `String`, so the `date+ ... > a string` would never be true. 
This lead to TBRs not to be "zeroed" correctly (or partially zeroed) when the pump is currently suspended.

(And if it was ever `true` - `firstResumeDate` would have been used instead of `lastSuspendDate`)

## Long TBRs handled incorrectly

The algorithm takes all TBRs and splits them into small chunks:
* first, split a TBR into chunks such that each chunk is not longer than 30 minutes
* then, split each chunk at profile basal schedule points (for example, if profile basal is set hourly - chunks are split at the beginning of every hour)

Due to this, if a TBR happens to be longer than 30 minutes - it is split into parts. And if the first part also needs to be split at profile schedule point - everything after the first 30 minutes gets completely lost.

So a long 60-minute zero temp can become a 30-minute zero temp (and the rest is calculated as if it was the normal profile rate). Same with high TBRs (although less likely because it'd have to be an uninterrupted long TBR).

Additionally, the suspends are transformed into zero temps, and also split and mixed together with the real TBRs, and it becomes a complete mess. See the screenshot below. I cannot even explain what is going on there.

(on the screenshots: Red line - calculated IOB before fix, green line - after the fix.)

<details>
  <summary>IOB going down after suspend for ~20 (why?) minutes, correctly. Then goes up, while the pump is still suspended.</summary>
  Red rectangle at the top is a (very long) pump suspension. 
  <br>

   <img width="400" src="https://github.com/user-attachments/assets/05f2c78c-fffd-48d8-b152-4bc82fac3e15" />
</details>

A few more examples (without pump suspension):

<details>
  <summary>Long zero temp becomes a 30-minute zero temp, rest is profile rate. IOB going up during zero temp.</summary>
   <img width="400" src="https://github.com/user-attachments/assets/c5658a00-bd34-4494-888e-707ee16033ea" />
</details>

<details>
  <summary>Long high temp becomes a 30-minute high temp, rest is profile rate. IOB going down during high temp.</summary>
   <img width="400" src="https://github.com/user-attachments/assets/f83851bf-7b08-4254-bc82-c12aba07bd6a" />
</details>
<details>
  <summary>A couple of real-life examples.</summary>
   <img width="400" src="https://github.com/user-attachments/assets/0c79bc1c-02be-46e2-b6fa-676ae28f9a90" />
   <img width="400" src="https://github.com/user-attachments/assets/2ea3ad23-7855-44ab-842f-1c17b9e652bc" />
</details>
