### PR TITLE
drop dependencies

### DIFF
--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tz = require('moment-timezone');
+var parseDate = require('../date-parse')
 var basal = require('../profile/basal');
 var getIOB = require('../iob');
 var ISF = require('../profile/isf');
@@ -13,8 +13,8 @@ function categorizeBGDatums(opts) {
     var treatments = opts.treatments;
     // this sorts the treatments collection in order.
     treatments.sort(function (a, b) {
-        var aDate = new Date(tz(a.timestamp));
-        var bDate = new Date(tz(b.timestamp));
+        var aDate = parseDate(a.timestamp);
+        var bDate = parseDate(b.timestamp);
         //console.error(aDate);
         return bDate.getTime() - aDate.getTime();
     });
@@ -39,7 +39,7 @@ function categorizeBGDatums(opts) {
 
             if (!obj.dateString)
             {
-                obj.dateString = new Date(tz(obj.date)).toISOString();
+                obj.dateString = parseDate(obj.date).toISOString();
             }
             return obj;
         }).filter(function filterRecords(obj) {
@@ -101,7 +101,7 @@ function categorizeBGDatums(opts) {
         var treatment = treatments[i];
         //console.error(treatment);
         if (treatment) {
-            var treatmentDate = new Date(tz(treatment.timestamp));
+            var treatmentDate = parseDate(treatment.timestamp);
             var treatmentTime = treatmentDate.getTime();
             var glucoseDatum = bucketedData[bucketedData.length-1];
             //console.error(glucoseDatum);
@@ -135,7 +135,7 @@ function categorizeBGDatums(opts) {
         treatment = treatments[treatments.length-1];
         var myCarbs = 0;
         if (treatment) {
-            treatmentDate = new Date(tz(treatment.timestamp));
+            treatmentDate = parseDate(treatment.timestamp);
             treatmentTime = treatmentDate.getTime();
             //console.error(treatmentDate);
             if ( treatmentTime < BGTime ) {

--- a/lib/calc-glucose-stats.js
+++ b/lib/calc-glucose-stats.js
@@ -1,15 +1,17 @@
 var parseDate = require('./date-parse')
-const _ = require('lodash');
 const stats = require('./glucose-stats');
 
 module.exports = {};
 const calcStatsExports = module.exports;
 
 calcStatsExports.updateGlucoseStats = (options) => {
-  var hist = _.map(_.sortBy(options.glucose_hist, 'dateString'), function readDate(value) {
-      value.readDateMills = parseDate(value.dateString).getTime();
-      return value;
-    });
+  var hist = options.glucose_hist
+    .slice()
+    .sort((a, b) => parseDate(a.dateString) - parseDate(b.dateString))
+    .map(value => ({
+      ...value,
+      readDateMills: parseDate(value.dateString).getTime(),
+    }));
 
   if (hist && hist.length > 0) {
     var noise_val = stats.calcSensorNoise(null, hist, null, null);

--- a/lib/calc-glucose-stats.js
+++ b/lib/calc-glucose-stats.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+var parseDate = require('./date-parse')
 const _ = require('lodash');
 const stats = require('./glucose-stats');
 
@@ -7,7 +7,7 @@ const calcStatsExports = module.exports;
 
 calcStatsExports.updateGlucoseStats = (options) => {
   var hist = _.map(_.sortBy(options.glucose_hist, 'dateString'), function readDate(value) {
-      value.readDateMills = moment(value.dateString).valueOf();
+      value.readDateMills = parseDate(value.dateString).getTime();
       return value;
     });
 

--- a/lib/date-parse.js
+++ b/lib/date-parse.js
@@ -14,7 +14,10 @@ exports = module.exports = function parseDate(d) {
   // if it's a string -> parse
   if (typeof d === 'string') {
     const parsed = Date.parse(d);
-    return isNaN(parsed) ? null : new Date(parsed);
+    if (isNaN(parsed)) {
+      throw new TypeError(`Invalid date input: ${d}`);
+    }
+    return new Date(parsed);
   }
 
   // unsupported type

--- a/lib/date-parse.js
+++ b/lib/date-parse.js
@@ -1,0 +1,22 @@
+exports = module.exports = function parseDate(d) {
+  if (d == null) return null;
+
+  // if it's already a Date
+  if (d instanceof Date) {
+    return new Date(d.getTime()); // copy
+  }
+
+  // if it's a number -> milliseconds since epoch
+  if (typeof d === 'number') {
+    return new Date(d);
+  }
+
+  // if it's a string -> parse
+  if (typeof d === 'string') {
+    const parsed = Date.parse(d);
+    return isNaN(parsed) ? null : new Date(parsed);
+  }
+
+  // unsupported type
+  throw new TypeError(`Unsupported date input: ${typeof d}`);
+}

--- a/lib/date-parse.js
+++ b/lib/date-parse.js
@@ -1,25 +1,32 @@
 exports = module.exports = function parseDate(d) {
-  if (d == null) return null;
+  if (typeof d === 'undefined') {
+    // for compatibility with moment()
+    return new Date();
+  }
 
-  // if it's already a Date
+  if (d === null) {
+    throw new TypeError(`Null date input`);
+  }
+
   if (d instanceof Date) {
     return new Date(d.getTime()); // copy
   }
 
-  // if it's a number -> milliseconds since epoch
   if (typeof d === 'number') {
-    return new Date(d);
+    const date = new Date(d);
+    if (!date) {
+        throw new TypeError(`Invalid date input: ${d}`);
+    }
+    return date;
   }
 
-  // if it's a string -> parse
   if (typeof d === 'string') {
     const parsed = Date.parse(d);
     if (isNaN(parsed)) {
-      throw new TypeError(`Invalid date input: ${d}`);
+      throw new TypeError(`Invalid date input (string): ${d}`);
     }
     return new Date(parsed);
   }
 
-  // unsupported type
   throw new TypeError(`Unsupported date input: ${typeof d}`);
 }

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -5,7 +5,7 @@ var get_iob = require('../iob');
 var find_insulin = require('../iob/history');
 var isf = require('../profile/isf');
 var find_meals = require('../meal/history');
-var tz = require('moment-timezone');
+var parseDate = require('../date-parse')
 var percentile = require('../percentile');
 
 function detectSensitivity(inputs) {
@@ -57,8 +57,8 @@ function detectSensitivity(inputs) {
     };
     var meals = find_meals(mealinputs);
     meals.sort(function (a, b) {
-        var aDate = new Date(tz(a.timestamp));
-        var bDate = new Date(tz(b.timestamp));
+        var aDate = parseDate(a.timestamp);
+        var bDate = parseDate(b.timestamp);
         //console.error(aDate);
         return bDate.getTime() - aDate.getTime();
     });
@@ -123,7 +123,7 @@ function detectSensitivity(inputs) {
         var treatment = meals[i];
         //console.error(treatment);
         if (treatment) {
-            var treatmentDate = new Date(tz(treatment.timestamp));
+            var treatmentDate = parseDate(treatment.timestamp);
             var treatmentTime = treatmentDate.getTime();
             var glucoseDatum = bucketed_data[0];
             //console.error(glucoseDatum);
@@ -206,7 +206,7 @@ function detectSensitivity(inputs) {
         // the current BG data point.  If so, add those carbs to COB.
         treatment = meals[meals.length-1];
         if (treatment) {
-            treatmentDate = new Date(tz(treatment.timestamp));
+            treatmentDate = parseDate(treatment.timestamp);
             treatmentTime = treatmentDate.getTime();
             if ( treatmentTime < BGTime ) {
                 if (treatment.carbs >= 1) {

--- a/lib/glucose-stats.js
+++ b/lib/glucose-stats.js
@@ -1,7 +1,4 @@
 
-
-const moment = require('moment');
-
 const log = console.error;
 
 /* eslint-disable-next-line no-unused-vars */
@@ -134,8 +131,8 @@ calcStatsExports.calcTrend = (calcGlucose, glucoseHist, lastCal, sgv) => {
     let maxDate = null;
     let timeSpan = 0;
     let totalDelta = 0;
-    const currentTime = sgv ? moment(sgv.readDateMills)
-      : moment(glucoseHist[glucoseHist.length - 1].readDateMills);
+    const currentTime = sgv ? new Date(sgv.readDateMills)
+      : new Date(glucoseHist[glucoseHist.length - 1].readDateMills);
 
     sgvHist = [];
 

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var basalprofile = require('../profile/basal.js');
-var _ = require('lodash');
 var parseDate = require('../date-parse')
 
 function splitTimespanWithOneSplitter(event,splitter) {
@@ -18,8 +17,8 @@ function splitTimespanWithOneSplitter(event,splitter) {
 
         if (event.duration > 30 || (startMinutes < splitter.minutes && endMinutes > splitter.minutes) || (endMinutes > 1440 && splitter.minutes < (endMinutes - 1440))) {
 
-            var event1 = _.cloneDeep(event);
-            var event2 = _.cloneDeep(event);
+          var event1 = structuredClone(event);
+            var event2 = structuredClone(event);
 
             var event1Duration = 0;
 
@@ -57,20 +56,22 @@ function splitTimespan(event, splitterMoments) {
 
         var resultArray = [];
 
-        _.forEach(results,function split(o) {
+        for (const o of results) {
             splitFound = false;
-            _.forEach(splitterMoments,function split(p) {
-                var splitResult = splitTimespanWithOneSplitter(o,p);
+
+            for (const p of splitterMoments) {
+                const splitResult = splitTimespanWithOneSplitter(o, p);
                 if (splitResult.length > 1) {
-                    resultArray = resultArray.concat(splitResult);
-                    splitFound = true;
-                    return false;
-                }
-            });
+                  resultArray.push(...splitResult);
+                  splitFound = true;
+                  break;
+               }
+            }
 
-            if (!splitFound) resultArray = resultArray.concat([o]);
-
-        });
+            if (!splitFound) {
+                resultArray.push(o);
+            }
+        }
 
         results = resultArray;
     }
@@ -125,7 +126,7 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
                 // event started before the suspend, but finished after the suspend started
 
                 if ((events[j].date+events[j].duration*60*1000) > (suspend.date+suspend.duration*60*1000)) {
-                    var event2 = _.cloneDeep(events[j]);
+                    var event2 = structuredClone(events[j]);
 
                     var event2StartDate = moment(suspend.started_at).add(suspend.duration,'minutes');
 
@@ -198,9 +199,9 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         }
     }
 
-    pumpSuspends = _.sortBy(pumpSuspends, 'date');
+    pumpSuspends.sort((a, b) => parseDate(a.date) - parseDate(b.date));
 
-    pumpResumes = _.sortBy(pumpResumes, 'date');
+    pumpResumes.sort((a, b) => parseDate(a.date) - parseDate(b.date));
 
     if (pumpResumes.length > 0) {
         firstResumeTime = pumpResumes[0].timestamp;
@@ -380,7 +381,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
 
     // Check for overlapping events and adjust event lengths in case of overlap
 
-    tempHistory = _.sortBy(tempHistory, 'date');
+    tempHistory.sort((a, b) => a.date - b.date);
 
     for (i=0; i+1 < tempHistory.length; i++) {
         if (tempHistory[i].date + tempHistory[i].duration*60*1000 > tempHistory[i+1].date) {
@@ -397,22 +398,21 @@ function calcTempTreatments (inputs, zeroTempDuration) {
 
     var splitterEvents = [];
 
-    _.forEach(profile_data.basalprofile,function addSplitter(o) {
-        var splitterEvent = {};
-        splitterEvent.type = 'recurring';
-        splitterEvent.minutes = o.minutes;
+    profile_data.basalprofile.forEach(o => {
+        const splitterEvent = {
+          type: 'recurring',
+          minutes: o.minutes
+        };
         splitterEvents.push(splitterEvent);
     });
 
     // iterate through the events and split at basal break points if needed
 
     var splitHistoryByBasal = [];
-
-    _.forEach(tempHistory, function splitEvent(o) {
-        splitHistoryByBasal = splitHistoryByBasal.concat(splitTimespan(o,splitterEvents));
+    tempHistory.forEach(o => {
+        splitHistoryByBasal = splitHistoryByBasal.concat(splitTimespan(o, splitterEvents));
     });
-
-    tempHistory = _.sortBy(tempHistory, function(o) { return o.date; });
+    tempHistory.sort((a, b) => a.date - b.date);
 
     var suspend_zeros_iob = false;
 
@@ -425,28 +425,28 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         // times as required to account for pump suspends
         var splitHistory = [];
 
-        _.forEach(splitHistoryByBasal, function splitSuspendEvent(o) {
-            var splitEvents = splitAroundSuspends(o, pumpSuspends, firstResumeTime, suspendedPrior, lastSuspendTime, currentlySuspended);
-            splitHistory = splitHistory.concat(splitEvents);
+        splitHistoryByBasal.forEach(o => {
+            var splitEvents = splitAroundSuspends(
+              o, pumpSuspends, firstResumeTime, suspendedPrior, lastSuspendTime, currentlySuspended
+            );
+            splitHistory.push(...splitEvents);
         });
 
         var zTempSuspendBasals = [];
 
         // Any existing temp basals during times the pump was suspended are now deleted
         // Add 0 temp basals to negate the profile basal rates during times pump is suspended
-        _.forEach(pumpSuspends, function createTempBasal(o) {
+        pumpSuspends.forEach(o => {
             if (typeof o.duration !== 'undefined') {
-                var zTempBasal = [{
-                    _type: 'SuspendBasal',
-                    rate: 0,
-                    duration: o.duration,
-                    date: o.date,
-                    started_at: o.started_at
-                }];
-                zTempSuspendBasals = zTempSuspendBasals.concat(zTempBasal);
+                zTempSuspendBasals.push({
+                  _type: 'SuspendBasal',
+                  rate: 0,
+                  duration: o.duration,
+                  date: o.date,
+                  started_at: o.started_at
+                });
             }
         });
-
         // Add temp suspend basal for maximum DIA (8) up to the resume time
         // if there is no matching suspend in the history before the first
         // resume
@@ -496,14 +496,14 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         // Add the new 0 temp basals to the splitHistory.
         // We have to split the new zero temp basals by the profile
         // basals just like the other temp basals.
-        _.forEach(zTempSuspendBasals, function splitEvent(o) {
-            splitHistory = splitHistory.concat(splitTimespan(o,splitterEvents));
-        });
+      zTempSuspendBasals.forEach(o => {
+          splitHistory = splitHistory.concat(splitTimespan(o, splitterEvents));
+      });
     } else {
         splitHistory = splitHistoryByBasal;
     }
 
-    splitHistory = _.sortBy(splitHistory, function(o) { return o.date; });
+    splitHistory.sort((a, b) => a.date - b.date);
 
     // tempHistory = splitHistory;
 
@@ -519,7 +519,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var target_bg;
 
             var currentRate = profile_data.current_basal;
-            if (!_.isEmpty(profile_data.basalprofile)) {
+            if (profile_data.basalprofile && profile_data.basalprofile.length > 0) {
                 currentRate = basalprofile.basalLookup(profile_data.basalprofile,new Date(currentItem.timestamp));
             }
 
@@ -567,7 +567,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         }
     }
     var all_data =  [ ].concat(tempBoluses).concat(tempHistory);
-    all_data = _.sortBy(all_data, 'date');
+    all_data.sort((a, b) => a.date - b.date);
     return all_data;
 }
 exports = module.exports = calcTempTreatments;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -17,7 +17,7 @@ function splitTimespanWithOneSplitter(event,splitter) {
 
         if (event.duration > 30 || (startMinutes < splitter.minutes && endMinutes > splitter.minutes) || (endMinutes > 1440 && splitter.minutes < (endMinutes - 1440))) {
 
-          var event1 = structuredClone(event);
+            var event1 = structuredClone(event);
             var event2 = structuredClone(event);
 
             var event1Duration = 0;
@@ -30,7 +30,7 @@ function splitTimespanWithOneSplitter(event,splitter) {
                 event1Duration = splitPoint - startMinutes;
             }
 
-            var event1EndDate = new Date(parseDate(event.started_at) + event1Duration * 60 * 1000); // plus minutes
+            var event1EndDate = new Date(parseDate(event.started_at).getTime() + event1Duration * 60 * 1000); // plus event1Duration minutes
 
             event1.duration = event1Duration;
 
@@ -199,9 +199,9 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         }
     }
 
-    pumpSuspends.sort((a, b) => parseDate(a.date) - parseDate(b.date));
+    pumpSuspends.sort((a, b) => a.date - b.date);
 
-    pumpResumes.sort((a, b) => parseDate(a.date) - parseDate(b.date));
+    pumpResumes.sort((a, b) => a.date - b.date);
 
     if (pumpResumes.length > 0) {
         firstResumeTime = pumpResumes[0].timestamp;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var tz = require('moment-timezone');
 var basalprofile = require('../profile/basal.js');
 var _ = require('lodash');
-var moment = require('moment');
+var parseDate = require('../date-parse')
 
 function splitTimespanWithOneSplitter(event,splitter) {
 
@@ -32,12 +31,12 @@ function splitTimespanWithOneSplitter(event,splitter) {
                 event1Duration = splitPoint - startMinutes;
             }
 
-            var event1EndDate = moment(event.started_at).add(event1Duration,'minutes');
+            var event1EndDate = new Date(parseDate(event.started_at) + event1Duration * 60 * 1000); // plus minutes
 
             event1.duration = event1Duration;
 
             event2.duration  = event.duration - event1Duration;
-            event2.timestamp = event1EndDate.format();
+            event2.timestamp = event1EndDate.toISOString();
             event2.started_at = new Date(event2.timestamp);
             event2.date = event2.started_at.getTime();
 
@@ -97,7 +96,7 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
         } else {
             currentEvent.duration = ((currentEvent.date+currentEvent.duration*60*1000)-firstResumeDate)/60/1000;
 
-            currentEvent.started_at = new Date(tz(firstResumeTime));
+            currentEvent.started_at = parseDate(firstResumeTime);
             currentEvent.date = firstResumeDate
         }
     }
@@ -130,8 +129,8 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
 
                     var event2StartDate = moment(suspend.started_at).add(suspend.duration,'minutes');
 
-                    event2.timestamp = event2StartDate.format();
-                    event2.started_at = new Date(tz(event2.timestamp));
+                    event2.timestamp = event2StartDate.toISOString();
+                    event2.started_at = parseDate(event2.timestamp);
                     event2.date = suspend.date+suspend.duration*60*1000;
 
                     event2.duration = ((events[j].date+events[j].duration*60*1000) - (suspend.date+suspend.duration*60*1000))/60/1000;
@@ -148,8 +147,8 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
 
                 var eventStartDate = moment(suspend.started_at).add(suspend.duration,'minutes');
 
-                events[j].timestamp = eventStartDate.format();
-                events[j].started_at = new Date(tz(events[j].timestamp));
+                events[j].timestamp = eventStartDate.toISOString();
+                events[j].started_at = parseDate(events[j].timestamp);
                 events[j].date = suspend.date + suspend.duration*60*1000;
             }
         }
@@ -172,7 +171,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
     var currentlySuspended = false;
     var suspendError = false;
 
-    var now = new Date(tz(inputs.clock));
+    var now = parseDate(inputs.clock);
 
     if(inputs.history24) {
         var pumpHistory =  [ ].concat(inputs.history).concat(inputs.history24);
@@ -188,12 +187,12 @@ function calcTempTreatments (inputs, zeroTempDuration) {
 
         if (current._type === "PumpSuspend") {
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(current.timestamp));
+            temp.started_at = parseDate(current.timestamp);
             temp.date = temp.started_at.getTime();
             pumpSuspends.push(temp);
         } else if (current._type === "PumpResume") {
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(current.timestamp));
+            temp.started_at = parseDate(current.timestamp);
             temp.date = temp.started_at.getTime();
             pumpResumes.push(temp);
         }
@@ -269,7 +268,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         if (current.created_at) {
             current.timestamp = current.created_at;
         }
-        var currentRecordTime = new Date(tz(current.timestamp));
+        var currentRecordTime = parseDate(current.timestamp);
         //console.error(current);
         //console.error(currentRecordTime,lastRecordTime);
         // ignore duplicate or out-of-order records (due to 1h and 24h overlap, or timezone changes)
@@ -283,7 +282,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         if (current._type === "Bolus") {
             var temp = {};
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(current.timestamp));
+            temp.started_at = parseDate(current.timestamp);
             if (temp.started_at > now) {
                 //console.error("Warning: ignoring",current.amount,"U bolus in the future at",temp.started_at);
                 process.stderr.write(" "+current.amount+"U @ "+temp.started_at);
@@ -297,21 +296,21 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             //"Bolus Wizard" refers to the Nightscout Bolus Wizard, not the Medtronic Bolus Wizard
             var temp = {};
             temp.timestamp = current.created_at;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             temp.insulin = current.insulin;
             tempBoluses.push(temp);
         } else if (current.enteredBy === "xdrip") {
             var temp = {};
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             temp.insulin = current.insulin;
             tempBoluses.push(temp);
         } else if (current.enteredBy ==="HAPP_App" && current.insulin) {
             var temp = {};
             temp.timestamp = current.created_at;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             temp.insulin = current.insulin;
             tempBoluses.push(temp);
@@ -320,7 +319,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             temp.rate = current.absolute;
             temp.duration = current.duration;
             temp.timestamp = current.created_at;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             tempHistory.push(temp);
         } else if (current.eventType === "Temp Basal") {
@@ -333,7 +332,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
                 temp.rate = current.amount / current.duration * 60;
             }
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             tempHistory.push(temp);
         } else if (current._type === "TempBasal") {
@@ -360,7 +359,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var temp = {};
             temp.rate = rate;
             temp.timestamp = current.timestamp;
-            temp.started_at = new Date(tz(temp.timestamp));
+            temp.started_at = parseDate(temp.timestamp);
             temp.date = temp.started_at.getTime();
             temp.duration = duration;
             tempHistory.push(temp);
@@ -464,7 +463,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
 
             var suspendStart = new Date(max_dia_ago);
             var suspendStartDate = suspendStart.getTime()
-            var started_at = new Date(tz(suspendStart.toISOString()));
+            var started_at = parseDate(suspendStart);
 
             var zTempBasal = [{
                // add _type to aid debugging. It isn't used
@@ -481,7 +480,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         if (currentlySuspended) {
             var suspendStart = new Date(lastSuspendTime);
             var suspendStartDate = suspendStart.getTime()
-            var started_at = new Date(tz(suspendStart.toISOString()));
+            var started_at = parseDate(suspendStart);
 
             var zTempBasal = [{
                 _type: 'SuspendBasal',

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -128,7 +128,7 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
                 if ((events[j].date+events[j].duration*60*1000) > (suspend.date+suspend.duration*60*1000)) {
                     var event2 = structuredClone(events[j]);
 
-                    var event2StartDate = moment(suspend.started_at).add(suspend.duration,'minutes');
+                    var event2StartDate = new Date(parseDate(suspend.started_at).getTime() + suspend.duration * 60 * 1000);
 
                     event2.timestamp = event2StartDate.toISOString();
                     event2.started_at = parseDate(event2.timestamp);
@@ -146,7 +146,7 @@ function splitAroundSuspends (currentEvent, pumpSuspends, firstResumeTime, suspe
             
                 events[j].duration = ((events[j].date+events[j].duration*60*1000) - (suspend.date+suspend.duration*60*1000))/60/1000;
 
-                var eventStartDate = moment(suspend.started_at).add(suspend.duration,'minutes');
+                var eventStartDate = new Date(parseDate(suspend.started_at).getTime() + suspend.duration * 60 * 1000);
 
                 events[j].timestamp = eventStartDate.toISOString();
                 events[j].started_at = parseDate(events[j].timestamp);

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tz = require('moment-timezone');
+var parseDate = require('../date-parse')
 var find_insulin = require('./history');
 var calculate = require('./calculate');
 var sum = require('./total');
@@ -36,7 +36,7 @@ function generate (inputs, currentIOBOnly, treatments) {
     if (! /(Z|[+-][0-2][0-9]:?[034][05])+/.test(inputs.clock) ) {
         console.error("Warning: clock input " + inputs.clock + " is unzoned; please pass clock-zoned.json instead");
     }
-    var clock = new Date(tz(inputs.clock));
+    var clock = parseDate(inputs.clock);
 
     var lastBolusTime = new Date(0).getTime(); //clock.getTime());
     var lastTemp = {};

--- a/lib/meal/index.js
+++ b/lib/meal/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tz = require('moment-timezone');
+var parseDate = require('../date-parse')
 var find_meals = require('./history');
 var sum = require('./total');
 
@@ -16,7 +16,7 @@ function generate (inputs) {
   , basalprofile: inputs.basalprofile
   };
 
-  var clock = new Date(tz(inputs.clock));
+  var clock = parseDate(inputs.clock);
 
   return /* meal_data */ sum(opts, clock);
 }

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -22,6 +22,7 @@ function recentCarbs(opts, time) {
     var iob_inputs = {
         profile: profile_data
     ,   history: opts.pumphistory
+    ,   clock: time
     };
     var COB_inputs = {
         glucose_data: glucose_data

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tz = require('moment-timezone');
+var parseDate = require('../date-parse')
 var detectCarbAbsorption = require('../determine-basal/cob');
 
 function recentCarbs(opts, time) {
@@ -33,8 +33,8 @@ function recentCarbs(opts, time) {
 
     // this sorts the treatments collection in order.
     treatments.sort(function (a, b) {
-        var aDate = new Date(tz(a.timestamp));
-        var bDate = new Date(tz(b.timestamp));
+        var aDate = parseDate(a.timestamp);
+        var bDate = parseDate(b.timestamp);
         //console.error(aDate);
         return bDate.getTime() - aDate.getTime();
     });
@@ -47,7 +47,7 @@ function recentCarbs(opts, time) {
         var now = time.getTime();
         // consider carbs from up to 6 hours ago in calculating COB
         var carbWindow = now - 6 * 60*60*1000;
-        var treatmentDate = new Date(tz(treatment.timestamp));
+        var treatmentDate = parseDate(treatment.timestamp);
         var treatmentTime = treatmentDate.getTime();
         if (treatmentTime > carbWindow && treatmentTime <= now) {
             if (treatment.carbs >= 1) {

--- a/lib/profile/basal.js
+++ b/lib/profile/basal.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 /* Return basal rate(U / hr) at the provided timeOfDay */
 function basalLookup (schedules, now) {
 
@@ -11,7 +9,7 @@ function basalLookup (schedules, now) {
       nowDate = new Date();
     }
 
-    var basalprofile_data = _.sortBy(schedules, function(o) { return o.i; });
+    var basalprofile_data = schedules.slice().sort((a, b) => a.i - b.i);
     var basalRate = basalprofile_data[basalprofile_data.length-1].rate
     if (basalRate === 0) {
         // TODO - shared node - move this print to shared object.
@@ -31,7 +29,12 @@ function basalLookup (schedules, now) {
 
 
 function maxDailyBasal (inputs) {
-    var maxRate = _.maxBy(inputs.basals,function(o) { return Number(o.rate); });
+    var maxRate =
+      inputs.basals.length
+          ? inputs.basals.reduce((max, o) => // maxBy
+            Number(o.rate) > Number(max.rate) ? o : max
+          )
+          : null;
     return (Number(maxRate.rate) *1000)/1000;
 }
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -4,7 +4,6 @@ var basal = require('./basal');
 var targets = require('./targets');
 var isf = require('./isf');
 var carb_ratios = require('./carbs');
-var _ = require('lodash');
 
 var shared_node_utils = require('../../bin/oref0-shared-node-utils');
 var console_error = shared_node_utils.console_error;
@@ -131,11 +130,11 @@ function generate (final_result, inputs, opts) {
 
   profile.current_basal = basal.basalLookup(inputs.basals);
   profile.basalprofile = inputs.basals;
-  
-  _.forEach(profile.basalprofile, function(basalentry) {
-    basalentry.rate = +(Math.round(basalentry.rate + "e+3")  + "e-3");		
+
+  profile.basalprofile.forEach(basalentry => {
+    basalentry.rate = +(Math.round(basalentry.rate + 'e+3') + 'e-3');
   });
-  
+
   profile.max_daily_basal = basal.maxDailyBasal(inputs);
   profile.max_basal = basal.maxBasalLookup(inputs);
   if (profile.current_basal === 0) {
@@ -156,14 +155,14 @@ function generate (final_result, inputs, opts) {
   profile.min_bg = Math.round(range.min_bg);
   profile.max_bg = Math.round(range.max_bg);
   profile.bg_targets = inputs.targets;
-  
-  _.forEach(profile.bg_targets.targets, function(bg_entry) {
+
+  profile.bg_targets.targets.forEach(bg_entry => {
     bg_entry.high = Math.round(bg_entry.high);
     bg_entry.low = Math.round(bg_entry.low);
     bg_entry.min_bg = Math.round(bg_entry.min_bg);
     bg_entry.max_bg = Math.round(bg_entry.max_bg);
   });
-  
+
   delete profile.bg_targets.raw;
   
   profile.temptargetSet = range.temptargetSet;

--- a/lib/profile/isf.js
+++ b/lib/profile/isf.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 function isfLookup(isf_data, timestamp, lastResult) {
 
     var nowDate = timestamp;
@@ -16,7 +14,7 @@ function isfLookup(isf_data, timestamp, lastResult) {
         return [lastResult.sensitivity, lastResult];
     }
 
-    isf_data = _.sortBy(isf_data.sensitivities, function(o) { return o.offset; });
+    isf_data = isf_data.sensitivities.slice().sort((a, b) => a.offset - b.offset);
 
     var isfSchedule = isf_data[isf_data.length - 1];
 

--- a/lib/round-basal.js
+++ b/lib/round-basal.js
@@ -1,5 +1,3 @@
-var endsWith = require('lodash/endsWith');
-
 var round_basal = function round_basal(basal, profile) {
 
     /* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
@@ -16,7 +14,7 @@ var round_basal = function round_basal(basal, profile) {
         // Make sure optional model has been set
         if (typeof profile.model === 'string')
         {
-            if (endsWith(profile.model, "54") || endsWith(profile.model, "23"))
+            if (profile.model?.endsWith('54') || profile.model?.endsWith('23'))
             {
                 lowest_rate_scale = 40;
             }

--- a/package.json
+++ b/package.json
@@ -99,15 +99,6 @@
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {
-    "json": "^9.0.6",
-    "json-stable-stringify": "^1.0.1",
-    "lodash": "^4.17.15",
-    "moment": "^2.24.0",
-    "moment-timezone": "0.5.23",
-    "network": "^0.4.1",
-    "request": "^2.88.0",
-    "share2nightscout-bridge": "^0.2.1",
-    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "coveralls": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {
+    "yargs": "^13.2.2"
   },
   "devDependencies": {
     "coveralls": "^3.0.3",


### PR DESCRIPTION
oref0 was using two dependencies - moment-js (+ moment-timezone) and lodash

These dependencies made the resulting bundled JS files huge (1MB+).

moment-js is archived and deprecated (since quite a while ago), and it was only used for parsing date strings + a couple of helper functions. None of this is necessary because JS runtimes support these functions natively. 

So all usages of `moment(...)` were replaced with a new helper function - `parseDate` which is built using the JS-native `Date` class. It supports strings. numbers and dates as input (to mimick `moment()`).

As for lodash - it was mostly used for its `_.forEach` function and a couple of helpers. All of which are also natively supported by JS runtimes.

These changes resulted in JS bundle sizes going down from over 1MB to under 20KB.